### PR TITLE
Convert print statements to logging

### DIFF
--- a/pytorch2timeloop/converter_pytorch.py
+++ b/pytorch2timeloop/converter_pytorch.py
@@ -1,5 +1,6 @@
 """ Convert Trained PyTorch Models to Workloads """
 
+import logging
 import os
 from typing import Any
 
@@ -8,6 +9,8 @@ import yaml
 
 from pytorch2timeloop.utils.hooks import hook_for
 from torch import nn
+
+logger = logging.getLogger(__name__)
 
 
 def convert_model_with_sample_input(model: nn.Module, sample_input: Any, batch_size: int, model_name: str, save_dir: str, exception_module_names=[]):
@@ -25,7 +28,7 @@ def convert_model_with_sample_input(model: nn.Module, sample_input: Any, batch_s
     :param save_dir: the directory to save the output in
     :param exception_module_names: a list of fragments of module names to ignore (can be a prefix, suffix, or infix).
     """
-    print("converting {} in {} model ...".format("all", model_name))
+    logger.info("converting {} in {} model ...".format("all", model_name))
 
     layer_data = _extract_layer_data(model, sample_input, convert_fc=True, batch_size=batch_size,
                                      exception_module_names=exception_module_names)
@@ -49,7 +52,7 @@ def convert_model(model: nn.Module, input_size: tuple, batch_size: int, model_na
     :param exception_module_names: a list of fragments of module names to ignore (can be a prefix, suffix, or infix).
     """
 
-    print("converting {} in {} model ...".format("nn.Conv2d" if not convert_fc else "nn.Conv2d and nn.Linear", model_name))
+    logger.info("converting {} in {} model ...".format("nn.Conv2d" if not convert_fc else "nn.Conv2d and nn.Linear", model_name))
 
     sample_input = torch.rand(2, *input_size).type(torch.FloatTensor)
     layer_data = _extract_layer_data(model, sample_input, convert_fc=convert_fc,
@@ -110,4 +113,4 @@ def _convert_from_layer_data(layer_data, model_name, save_dir):
         with open(file_path, 'w') as f:
             f.write(yaml.dump(problem.to_yaml()))
 
-    print("conversion complete!\n")
+    logger.info("conversion complete!\n")

--- a/pytorch2timeloop/utils/hooks.py
+++ b/pytorch2timeloop/utils/hooks.py
@@ -12,12 +12,15 @@ To add support for a new layer type, add a new hook type and return it from hook
 You may also need to add a new `LayerDescription` if the layer is very different from the ones that are already here.
 """
 
+import logging
 from typing import Optional, Callable, Any
 
 import torch.nn as nn
 import transformers.models.distilbert.modeling_distilbert
 
 from pytorch2timeloop.utils.layer_descriptions import DepthWiseConvLayerDescription, ConvLayerDescription, MatrixMatrixMultiplyLayerDescription
+
+logger = logging.getLogger(__name__)
 
 
 def _null_hook(summary, batch_size):
@@ -225,4 +228,4 @@ def hook_for(module: nn.Module, summary: list, batch_size: int, convert_fc=False
     elif isinstance(module, transformers.models.bert.modeling_bert.BertSelfAttention):
         return _multihead_self_attention(summary, batch_size)
 
-    print("unknown module type", module.__class__)
+    logger.warning("unknown module type %s", module.__class__)


### PR DESCRIPTION
As explained in #5, it is not always desirable for libraries that messages are printed into standard output.

This PR changes print statements for messages like
```
converting nn.Conv2d and nn.Linear in out model ...
```
into log messages.

Logging allows for finer tuning for what to do with the printed output.

Also, by default it goes to standard error, which means that it does not
interfere with other scripts standard output.

Users of pytorch2timeloop-converter can then decide to print all messages with a setup like this:
```python
import logging
logging.basicConfig(level=logging.DEBUG)
```
or decide to silence specific loggers
```python
logging.getLogger("pytorch2timeloop.converter_pytorch").propagate = False
logging.getLogger("pytorch2timeloop.utils.hooks").propagate = False

logging.getLogger("pytorch2timeloop").propagate = False  # silence both
```

Fixes #5 