### PR TITLE
Update torch==1.8, torchvision==0.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name='pytorch2timeloop',
         version='0.2',
         url='https://github.com/Accelergy-Project/pytorch2timeloop-converter',
         license='MIT',
-        install_requires=["torch>=1.7", "torchvision>=0.8", "numpy>=1.21", "pyyaml>=5.3", "transformers>=4.26.0"],
+        install_requires=["torch==1.8", "torchvision==0.8", "numpy==1.21", "pyyaml==5.3", "transformers==4.26.0"],
         python_requires='>=3.6',
         include_package_data=True,
         packages=find_packages())

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name='pytorch2timeloop',
         version='0.2',
         url='https://github.com/Accelergy-Project/pytorch2timeloop-converter',
         license='MIT',
-        install_requires=["torch==1.8", "torchvision==0.9", "numpy==1.21", "pyyaml==5.3", "transformers==4.26.0"],
+        install_requires=["torch==1.8", "torchvision==0.9.1", "numpy==1.21", "pyyaml==5.3", "transformers==4.26.0"],
         python_requires='>=3.6',
         include_package_data=True,
         packages=find_packages())

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name='pytorch2timeloop',
         version='0.2',
         url='https://github.com/Accelergy-Project/pytorch2timeloop-converter',
         license='MIT',
-        install_requires=["torch==1.7", "torchvision==0.8", "numpy==1.21", "pyyaml==5.3", "transformers==4.26.0"],
+        install_requires=["torch>=1.7", "torchvision>=0.8", "numpy>=1.21", "pyyaml>=5.3", "transformers>=4.26.0"],
         python_requires='>=3.6',
         include_package_data=True,
         packages=find_packages())

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name='pytorch2timeloop',
         version='0.2',
         url='https://github.com/Accelergy-Project/pytorch2timeloop-converter',
         license='MIT',
-        install_requires=["torch==1.8", "torchvision==0.8", "numpy==1.21", "pyyaml==5.3", "transformers==4.26.0"],
+        install_requires=["torch==1.8", "torchvision==0.9", "numpy==1.21", "pyyaml==5.3", "transformers==4.26.0"],
         python_requires='>=3.6',
         include_package_data=True,
         packages=find_packages())


### PR DESCRIPTION
Pytorch does not provide wheel of torch==1.7 and torchvision==0.8 for arm64 architecture. It provides cpu wheel from torch==1.8 and torchvision==0.9.1. 